### PR TITLE
temp remove data module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,3 @@ resource "google_dns_response_policy_rule" "redis_psc_dns_rule" {
     }
   }
 }
-
-data "rediscloud_private_service_connect" "redis_psc_data" {
-  subscription_id = var.subscription_id
-}


### PR DESCRIPTION
The data module is processed before the resource is created, causing the module to fail to create the PSC.